### PR TITLE
Ability to specify audience and subject for jwt tokens

### DIFF
--- a/oauth2-mock/handlers/token/token.go
+++ b/oauth2-mock/handlers/token/token.go
@@ -14,9 +14,13 @@ import (
 )
 
 const (
-	grantType = "grant_type"
-	scope     = "scope"
-	audience  = "audience"
+	grantTypeParam   = "grant_type"
+	scopeParam       = "scope"
+	audienceParam    = "audience"
+	subjectParam     = "subject"
+	tokenFormatParam = "token_format"
+	defaultAudience  = "default"
+	defaultSubject   = "test"
 )
 
 type Handler struct {
@@ -32,12 +36,12 @@ func NewHandler(readToken uuid.UUID, readWriteToken, noScopeToken uuid.UUID, iss
 }
 
 func (h Handler) Handle(c *gin.Context) {
-	grant := c.PostForm(grantType)
-	scope := c.PostForm(scope)
+	grant := c.PostForm(grantTypeParam)
+	scope := c.PostForm(scopeParam)
 
-	tokenFormat := c.Query("token_format")
+	tokenFormat := c.Query(tokenFormatParam)
 	if tokenFormat == "" {
-		tokenFormat = c.PostForm("token_format")
+		tokenFormat = c.PostForm(tokenFormatParam)
 	}
 
 	switch grant {
@@ -67,8 +71,17 @@ func (h Handler) Handle(c *gin.Context) {
 		default:
 			fallthrough
 		case "jwt":
-			aud := c.PostForm(audience)
-			rsaJwt, err := h.NewRSAJWT(scope, aud)
+			audience, audProvided := c.GetPostForm(audienceParam)
+			if !audProvided {
+				audience = defaultAudience // for backward compatibility
+			}
+
+			subject, subProvided := c.GetPostForm(subjectParam)
+			if !subProvided {
+				subject = defaultSubject // for backward compatibility
+			}
+
+			rsaJwt, err := h.NewRSAJWT(scope, audience, subject)
 			if err != nil {
 				_ = c.Error(err)
 				c.Status(http.StatusInternalServerError)
@@ -83,18 +96,21 @@ func (h Handler) Handle(c *gin.Context) {
 	}
 }
 
-func (h Handler) NewRSAJWT(scp string, aud string) ([]byte, error) {
-	builder := jwt.NewBuilder().Issuer(h.IssuerURL).NotBefore(time.Now()).IssuedAt(time.Now()).Expiration(time.Now().Add(1 * time.Hour))
+func (h Handler) NewRSAJWT(scope string, audience string, subject string) ([]byte, error) {
+	builder := jwt.NewBuilder().
+		Issuer(h.IssuerURL).
+		IssuedAt(time.Now()).
+		NotBefore(time.Now().Add(-1 * time.Hour)).
+		Expiration(time.Now().Add(1 * time.Hour))
 
-	if aud == "" {
-		aud = "default"
+	if subject != "" {
+		builder.Subject(subject)
 	}
-
-	builder.Subject("test")
-	builder.Audience(strings.Split(aud, ","))
-
-	if scp != "" {
-		builder.Claim("scope", scp)
+	if audience != "" {
+		builder.Audience(strings.Split(audience, ","))
+	}
+	if scope != "" {
+		builder.Claim("scope", scope)
 	}
 
 	t, err := builder.Build()


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- subject in now configurable
- both subject and audience may be empty (...&audience=&subject=&...)
- more meaningful variable names

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
